### PR TITLE
Update README to correctly describe Hussy.Net as a .NET dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ﻿# 💃 Hussy.Net
 
-Hussy.Net is an esoteric programming language designed for and by C# developers with code golf in mind. It is a minified adaptation of the C# programming language leveraging modern features for clean and concise code.
+Hussy.Net is an esoteric dialect of .NET designed for and by C# developers with code golf in mind. It leverages modern features of .NET for clean and concise code, making it an ideal choice for code golfing challenges within the .NET ecosystem.
 
 ![License](https://img.shields.io/github/license/tacosontitan/Hussy.Net?logo=github&style=for-the-badge)
 
 > [!IMPORTANT]
-> Hussy.Net is not designed to compete with other golfing languages, but rather to allow C# developers to participate in golfing challenges with a leg to stand on.
+> Hussy.Net is not designed to compete with other golfing languages, but rather to provide a familiar environment for C# developers to participate in golfing challenges.
 
 ## 🚀 Getting Started
 


### PR DESCRIPTION
Related to #61

Updates the README.md to accurately describe Hussy.Net as a .NET dialect, aligning with the project's true nature and addressing the issue raised.
- **Description Update**: Changes the initial description of Hussy.Net from "an esoteric programming language" to "an esoteric dialect of .NET", clarifying its purpose and scope within the .NET ecosystem.
- **Emphasis on Code Golfing**: Highlights Hussy.Net's role in code golfing for C# developers, ensuring the README reflects the project's focus on providing a familiar environment for golfing challenges.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tacosontitan/Hussy.Net/issues/61?shareId=a7911768-e2e4-4d0b-8cfd-3b09d6c7036e).